### PR TITLE
UPDATED: Toggle branch that fixes networking crash

### DIFF
--- a/Packages/version.d/Toggle
+++ b/Packages/version.d/Toggle
@@ -1,4 +1,4 @@
 # This specifies the appropriate version of Toggle
 TOGGLE_REPOSITORY="https://github.com/intelligent-agent/toggle"
-TOGGLE_BRANCH="develop"
+TOGGLE_BRANCH="1.3.x"
 TOGGLE_HOME="/usr/src/toggle"


### PR DESCRIPTION
Networking checks for a HwAddress are disabled on the branch.