### PR TITLE
Revise binding when switching to the chroot environment

### DIFF
--- a/build-image-in-chroot-end-to-end.sh
+++ b/build-image-in-chroot-end-to-end.sh
@@ -42,9 +42,9 @@ e2fsck -f ${DEVICE}p1
 resize2fs ${DEVICE}p1
 
 mount ${DEVICE}p1 ${MOUNTPOINT}
-mount -o bind /dev ${MOUNTPOINT}/dev
-mount -o bind /sys ${MOUNTPOINT}/sys
-mount -o bind /proc ${MOUNTPOINT}/proc
+mount --rbind /dev ${MOUNTPOINT}/dev
+mount --rbind /sys ${MOUNTPOINT}/sys
+mount -t proc none ${MOUNTPOINT}/proc
 
 rm ${MOUNTPOINT}/etc/resolv.conf
 cp /etc/resolv.conf ${MOUNTPOINT}/etc/resolv.conf


### PR DESCRIPTION
These are the changes suggested by @goeland86 in #82.

Unfortunately, they create a problem unmounting the TARGET /sys.

+ sed -i s/#enable_/enable_/ /boot/uEnv.txt
Now reboot!
+ echo 'Now reboot!'
+ status=0
+ set -e
+ rm /tmp/umikaze-root.5P8pUf/etc/resolv.conf
+ umount /tmp/umikaze-root.5P8pUf/proc
+ umount /tmp/umikaze-root.5P8pUf/sys
umount: /tmp/umikaze-root.5P8pUf/sys: target is busy.
[root@Droid-01 Umikaze]# mount
proc on /proc type proc (rw,nosuid,nodev,noexec,relatime)
sys on /sys type sysfs (rw,nosuid,nodev,noexec,relatime)
....
cgroup on /sys/fs/cgroup/rdma type cgroup (rw,nosuid,nodev,noexec,relatime,rdma)
cgroup on /sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
....
cgroup on /tmp/umikaze-root.5P8pUf/sys/fs/cgroup/rdma type cgroup (rw,nosuid,nodev,noexec,relatime,rdma)
cgroup on /tmp/umikaze-root.5P8pUf/sys/fs/cgroup/cpuset type cgroup (rw,nosuid,nodev,noexec,relatime,cpuset)
....
etc.   