### PR TITLE
Clean up sudo configuration

### DIFF
--- a/Packages/create_octoprint_user
+++ b/Packages/create_octoprint_user
@@ -19,3 +19,6 @@ chown -R octo:octo ${OCTOPRINT_HOME}
 chown -R octo:octo /usr/local/lib/python2.7/
 chown -R octo:octo /usr/local/bin
 chmod 755 -R /usr/local/lib/python2.7/
+
+# The octo user will get sudo permissions
+echo "# Explicit Permissions for Octoprint" > /etc/sudoers.d/octo

--- a/Packages/install_octoprint
+++ b/Packages/install_octoprint
@@ -39,16 +39,17 @@ mkdir -p /usr/share/models
 chown octo:octo /usr/share/models
 chmod 777 /usr/share/models
 
+# Annotate ports in /etc/services
+sed -i "/octoprint/d" /etc/services
+cat >>/etc/services <<EOF
+octoprint         5000/tcp
+EOF
+
 # Grant octo restart rights
-echo "%octo ALL=NOPASSWD: /bin/systemctl restart redeem.service" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /bin/systemctl restart toggle.service" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /bin/systemctl restart mjpg.service" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /bin/systemctl restart octoprint.service" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /sbin/reboot" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /sbin/shutdown -h now" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /sbin/poweroff" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /usr/bin/make -C /usr/local/src/redeem install" >> /etc/sudoers
-echo "%octo ALL=NOPASSWD: /usr/bin/make -C /usr/src/toggle install" >> /etc/sudoers
+echo "%octo ALL=NOPASSWD: /bin/systemctl restart octoprint.service" >> /etc/sudoers.d/octo
+echo "%octo ALL=NOPASSWD: /sbin/reboot" >> /etc/sudoers.d/octo
+echo "%octo ALL=NOPASSWD: /sbin/shutdown -h now" >> /etc/sudoers.d/octo
+echo "%octo ALL=NOPASSWD: /sbin/poweroff" >> /etc/sudoers.d/octo
 
 # Install systemd script
 cat > /lib/systemd/system/octoprint.service <<EOF
@@ -67,10 +68,3 @@ WantedBy=multi-user.target
 EOF
 
 systemctl enable octoprint
-#systemctl start octoprint
-
-# Annotate ports in /etc/services
-sed -i "/octoprint/d" /etc/services
-cat >>/etc/services <<EOF
-octoprint         5000/tcp
-EOF

--- a/Packages/install_octoprint_redeem
+++ b/Packages/install_octoprint_redeem
@@ -17,3 +17,6 @@ cd ${OCTOPRINT_REDEEM_HOME}
 git pull
 git checkout ${OCTOPRINT_REDEEM_BRANCH}
 python setup.py clean install
+
+# Provide permissions to execute install redeem
+echo "%octo ALL=NOPASSWD: /usr/bin/make -C /usr/local/src/redeem install" >> //etc/sudoers.d/octo

--- a/Packages/install_octoprint_toggle
+++ b/Packages/install_octoprint_toggle
@@ -17,3 +17,6 @@ cd ${OCTOPRINT_TOGGLE_HOME}
 git pull
 git checkout ${OCTOPRINT_TOGGLE_BRANCH}
 python setup.py clean install
+
+# Provide permissions to execute install toggle
+echo "%octo ALL=NOPASSWD: /usr/bin/make -C /usr/src/toggle install" >> /etc/sudoers.d/octo

--- a/Packages/install_redeem
+++ b/Packages/install_redeem
@@ -32,6 +32,15 @@ KERNEL=="spidev2.1", TAG+="systemd", SYMLINK+="steppers"
 KERNEL=="spidev1.1", TAG+="systemd", SYMLINK+="steppers", SYMLINK+="spidev2.1"
 EOF
 
+# Annotate ports in /etc/services
+sed -i "/redeem/d" /etc/services
+cat >>/etc/services <<EOF
+redeem       50000/tcp
+EOF
+
+# Provide permissions to restart redeem
+echo "%octo ALL=NOPASSWD: /bin/systemctl restart redeem.service" >> /etc/sudoers.d/octo
+
 # Install Umikaze specific systemd script
 cat > /lib/systemd/system/redeem.service <<EOF
 [Unit]
@@ -47,10 +56,3 @@ WantedBy=basic.target
 EOF
 
 systemctl enable redeem
-# systemctl start redeem
-
-# Annotate ports in /etc/services
-sed -i "/redeem/d" /etc/services
-cat >>/etc/services <<EOF
-redeem       50000/tcp
-EOF

--- a/Packages/install_toggle
+++ b/Packages/install_toggle
@@ -27,6 +27,23 @@ chown -R octo:octo ${TOGGLE_HOME}/
 # Provide permissions to restart toggle
 echo "%octo ALL=NOPASSWD: /bin/systemctl restart toggle.service" >> /etc/sudoers.d/octo
 
-cp systemd/toggle.service /lib/systemd/system/
+# Install Umikaze specific systemd script
+cat > /lib/systemd/system/toggle.service <<EOF
+[Unit]
+Description=The Redeem/Replicape Graphical user interface
+After=octoprint.service sgx-startup.service
+Requires=octoprint.service sgx-startup.service
+
+[Service]
+Type=simple
+ExecStartPre=/bin/systemctl stop getty@tty1.service
+ExecStartPre=/bin/bash -c '/bin/echo 0 > /sys/class/graphics/fbcon/cursor_blink'
+ExecStart=/usr/local/bin/toggle
+ExecStopPost=/bin/systemctl start getty@tty1.service
+ExecStopPost=/bin/bash -c '/bin/echo 1 > /sys/class/graphics/fbcon/cursor_blink'
+
+[Install]
+WantedBy=basic.target
+EOF
 
 systemctl enable toggle

--- a/Packages/install_toggle
+++ b/Packages/install_toggle
@@ -17,9 +17,16 @@ cd ${TOGGLE_HOME}
 git pull
 git checkout ${TOGGLE_BRANCH}
 python setup.py clean install
+
 # Make it writable for updates
-cp -r configs /etc/toggle
-chown -R octo:octo ${TOGGLE_HOME}/
-cp systemd/toggle.service /lib/systemd/system/
-systemctl enable toggle
+mkdir -p /etc/toggle
+cp -r configs/* /etc/toggle
 chown -R octo:octo /etc/toggle/
+chown -R octo:octo ${TOGGLE_HOME}/
+
+# Provide permissions to restart toggle
+echo "%octo ALL=NOPASSWD: /bin/systemctl restart toggle.service" >> /etc/sudoers.d/octo
+
+cp systemd/toggle.service /lib/systemd/system/
+
+systemctl enable toggle

--- a/Packages/install_videostreamer
+++ b/Packages/install_videostreamer
@@ -22,7 +22,12 @@ cd mjpg-streamer-experimental
 sed -i "s:add_subdirectory(plugins/input_raspicam):#add_subdirectory(plugins/input_raspicam):" CMakeLists.txt
 make
 make install
+
 echo "KERNEL==\"video0\", TAG+=\"systemd\"" > /etc/udev/rules.d/50-video.rules
+
+# Provide permissions to restart video streaming
+echo "%octo ALL=NOPASSWD: /bin/systemctl restart mjpg.service" >> /etc/sudoers.d/octo
+
 cat > /lib/systemd/system/mjpg.service << EOL
 [Unit]
 Description=Mjpg streamer
@@ -35,5 +40,5 @@ ExecStart=/usr/local/bin/mjpg_streamer -i "/usr/local/lib/mjpg-streamer/input_uv
 [Install]
 WantedBy=basic.target
 EOL
+
 systemctl enable mjpg.service
-systemctl start mjpg.service

--- a/make-kamikaze.sh
+++ b/make-kamikaze.sh
@@ -38,7 +38,7 @@ export PATH=`pwd`/Packages:$PATH
 install_sgx
 setup_port_forwarding
 install_dependencies
-create_user
+create_octoprint_user
 install_redeem
 virtualize_redeem
 install_octoprint


### PR DESCRIPTION
Rather than editing /etc/sudoers, the recommended practice
is to create files in /etc/sudoers.d/ which contain the
rules for a particular class of permitted uses

In addition to moving the octoprint permissions to such a file,
the individual lines are moved to the install script to which they pertain