### PR TITLE
Rebrand pipe end from /dev/redeem/

### DIFF
--- a/Packages/OctoPrint/config.yaml
+++ b/Packages/OctoPrint/config.yaml
@@ -35,9 +35,9 @@ plugins:
 printerParameters: {}
 serial:
   additionalPorts:
-  - /dev/octoprint_1
+  - /dev/redeem/octoprint
   baudrate: 115200
-  port: /dev/octoprint_1
+  port: /dev/redeem/octoprint
   timeout: {}
 server:
   commands:


### PR DESCRIPTION
This patches the configuration file for Octoprint

Note that this change MUST be coordinated with
corresponding changes to the pipe handler in Redeem (PR#173)
and the configuration file for Toggle (PR#15)

This renaming is introduced in the “BoxingDay” image. (Dec 2018)