### PR TITLE
The name of each build version MUST be customized

### DIFF
--- a/Packages/version.d/Kamikaze
+++ b/Packages/version.d/Kamikaze
@@ -4,5 +4,5 @@ UMIKAZE_BRANCH="master"
 UMIKAZE_HOME="/usr/src/Umikaze"
 
 # This specifies the Kamikaze Variables
-VERSION="Umikaze 2.2.1-RC1"
+VERSION="To_Be_Determined"
 ROOTPASS="kamikaze"


### PR DESCRIPTION
If the engineer building the system fails to change the
build name, having that name in the main tree causes
multiple builds to be generated with the same build name

At least one "-RC1" image has "escaped" prematurely.